### PR TITLE
Block running PHP files in the assets/images/ folder

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,6 +18,9 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ index.php/$1 [L]
 
+#Block running PHP files in the assets/images/ folder
+RewriteRule ^assets/images/.*\.(php|php4|php5)$ - [F,L,NC]
+
 # If we don't have mod_rewrite installed, all 404's
 # can be sent to index.php, and everything works as normal.
 # Submitted by: ElliotHaughin


### PR DESCRIPTION
As per the setup guide, you set 0777 permissions to assets/images/ folder which is a security risk if it is left open to the public. 

This rule should be apart of the default .htaccess file to lower the risk of this.
